### PR TITLE
feat: Implement multi-game instance architecture

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -54,7 +54,7 @@ Hooks.CanvasHook = {
     this.setupDPadListeners();
 
     this.handleEvent("particle_moved", (payload) => {
-      // CORREÇÃO: Mantém o estado visual completo da partícula entre as atualizações do servidor.
+      // Mantém o estado visual completo da partícula entre as atualizações do servidor.
       const existingParticle = this.particles.get(payload.id);
       if (existingParticle) {
         payload.lastRollAngle = existingParticle.lastRollAngle;

--- a/lib/snooker_game_ex/application.ex
+++ b/lib/snooker_game_ex/application.ex
@@ -5,9 +5,9 @@ defmodule SnookerGameEx.Application do
   It starts and supervises all the necessary processes for the game to run,
   including the web endpoint, PubSub, and the core game simulation engine.
   """
+
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
-  @moduledoc false
 
   use Application
 
@@ -16,28 +16,21 @@ defmodule SnookerGameEx.Application do
     children = [
       SnookerGameExWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:snooker_game_ex, :dns_cluster_query) || :ignore},
+      # Registry para partículas (pode ser usado globalmente com chaves de jogo)
       {Registry, keys: :unique, name: SnookerGameEx.ParticleRegistry},
+      # Novo Registry para instâncias de jogos
+      {Registry, keys: :unique, name: SnookerGameEx.GameRegistry},
       {Phoenix.PubSub, name: SnookerGameEx.PubSub},
-      # Start the Finch HTTP client for sending emails
       {Finch, name: SnookerGameEx.Finch},
-      # Start a worker by calling: SnookerGameEx.Worker.start_link(arg)
-      # {SnookerGameEx.Worker, arg},
-      # Start to serve requests, typically the last entry
       SnookerGameExWeb.Endpoint,
-      # Corrected Order: Start the Engine before the ParticleSupervisor
-      # to ensure the ETS table exists when particles are initialized.
-      SnookerGameEx.CollisionEngine,
-      SnookerGameEx.ParticleSupervisor
+      # Inicia o supervisor principal dos jogos
+      SnookerGameEx.GameSupervisor
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: SnookerGameEx.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
   @impl true
   def config_change(changed, _new, removed) do
     SnookerGameExWeb.Endpoint.config_change(changed, removed)

--- a/lib/snooker_game_ex/collision_engine.ex
+++ b/lib/snooker_game_ex/collision_engine.ex
@@ -1,8 +1,8 @@
 defmodule SnookerGameEx.CollisionEngine do
   @moduledoc """
-  The collision engine that orchestrates the game's physics simulation.
-  This version uses a synchronous, in-memory iterative solver to ensure
-  rock-solid collision resolution and prevent race conditions.
+  O motor de colisão que orquestra a simulação de física do jogo.
+  Esta versão usa um solver iterativo síncrono em memória para garantir
+  uma resolução de colisão robusta e prevenir condições de corrida.
   """
   use GenServer
   require Logger
@@ -11,28 +11,23 @@ defmodule SnookerGameEx.CollisionEngine do
   alias SnookerGameEx.Particle
   alias SnookerGameEx.Physics
 
+  # ... (constantes permanecem as mesmas) ...
   @frame_interval_ms 16
   @dt @frame_interval_ms / 1000.0
   @resolution_iterations 10
-
   @border_width 30.0
   @canvas_width 1000.0
   @canvas_height 500.0
   @particle_radius 15.0
   @particle_mass 1
-
   @world_bounds %{
     x: @border_width,
     y: @border_width,
     w: @canvas_width - @border_width * 2,
     h: @canvas_height - @border_width * 2
   }
-
-  @quadtree_a :quadtree_a
-  @quadtree_b :quadtree_b
   @quadtree_capacity 4
   @quadtree_max_depth 8
-
   @pocket_radius 25.0
   @pockets [
     %{pos: [@border_width, @border_width]},
@@ -50,40 +45,86 @@ defmodule SnookerGameEx.CollisionEngine do
   def particle_mass, do: @particle_mass
   def particle_radius, do: @particle_radius
   def world_bounds, do: @world_bounds
-  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  def start_link(opts) do
+    game_id = Keyword.fetch!(opts, :game_id)
+    GenServer.start_link(__MODULE__, opts, name: via_tuple(game_id))
+  end
+
+  def via_tuple(game_id),
+    do: {:via, Registry, {SnookerGameEx.GameRegistry, {__MODULE__, game_id}}}
 
   # --- Callbacks do GenServer ---
   @impl true
-  def init(_opts) do
-    Logger.info("Starting Collision Engine with Synchronous Iterative Solver.")
+  def init(opts) do
+    game_id = Keyword.fetch!(opts, :game_id)
+    ets_table = Keyword.fetch!(opts, :ets_table)
+    Logger.info("Starting Collision Engine for game #{game_id}")
+
+    # MUDANÇA: Criar as tabelas ETS diretamente aqui.
+    # O CollisionEngine agora é dono do ciclo de vida das tabelas.
+    # Usamos tabelas sem nome, operando por referência (TID).
+    quadtree_a_tid = :ets.new(:quadtree_a_storage, [:set, :public, read_concurrency: true])
+    quadtree_b_tid = :ets.new(:quadtree_b_storage, [:set, :public, read_concurrency: true])
+
     boundary = world_bounds()
-    Quadtree.init(@quadtree_a, boundary, @quadtree_capacity, @quadtree_max_depth)
-    Quadtree.init(@quadtree_b, boundary, @quadtree_capacity, @quadtree_max_depth)
+
+    # MUDANÇA: Chamar a nova função `initialize` do Quadtree, passando os TIDs.
+    Quadtree.initialize(quadtree_a_tid, boundary, @quadtree_capacity, @quadtree_max_depth)
+    Quadtree.initialize(quadtree_b_tid, boundary, @quadtree_capacity, @quadtree_max_depth)
     send(self(), :tick)
+
     {:ok,
      %{
+       game_id: game_id,
+       ets_table: ets_table,
        last_time: System.monotonic_time(),
        accumulator: 0.0,
-       active_table: @quadtree_a,
-       inactive_table: @quadtree_b
+       # MUDANÇA: Armazenar os TIDs (referências) em vez de nomes no estado.
+       active_table: quadtree_a_tid,
+       inactive_table: quadtree_b_tid
      }}
   end
 
+  @impl true
+  def terminate(_reason, state) do
+    Logger.info(
+      "Terminating Collision Engine and cleaning up ETS tables for game #{state.game_id}"
+    )
+
+    # MUDANÇA: Chamar :ets.delete diretamente, pois o CollisionEngine é o dono das tabelas.
+    :ets.delete(state.active_table)
+    :ets.delete(state.inactive_table)
+    :ok
+  end
+
+  # ... (o restante do módulo permanece exatamente o mesmo) ...
+
   @doc """
-  Restarts this supervisor
+  Reinicia este supervisor.
   """
-  def restart, do: Supervisor.stop(__MODULE__)
+  def restart(game_id) do
+    case Registry.lookup(SnookerGameEx.GameRegistry, game_id) do
+      [{pid, _}] -> Supervisor.terminate_child(SnookerGameEx.GameSupervisor, pid)
+      [] -> :ok
+    end
+
+    SnookerGameEx.GameSupervisor.start_game(game_id)
+  end
 
   @impl true
   def handle_info(:tick, state) do
     current_time = System.monotonic_time()
+
     delta_time_ms =
       (current_time - state.last_time)
       |> System.convert_time_unit(:native, :millisecond)
+
     capped_delta = min(delta_time_ms / 1000.0, 0.05)
     accumulator = state.accumulator + capped_delta
     new_accumulator = update_simulation_loop(accumulator, state)
     Process.send_after(self(), :tick, @frame_interval_ms)
+
     {:noreply,
      %{
        state
@@ -94,42 +135,43 @@ defmodule SnookerGameEx.CollisionEngine do
      }}
   end
 
-  # --- Lógica do Loop de Simulação ---
-
   defp update_simulation_loop(accumulator, state) do
     max_steps_per_tick = 1
     simulate_steps(accumulator, max_steps_per_tick, state)
   end
 
   defp simulate_steps(acc, remaining_steps, state) when acc >= @dt and remaining_steps > 0 do
-    broadcast_move_command()
+    broadcast_move_command(state.game_id, state.ets_table)
     detect_and_resolve_collisions(state)
     simulate_steps(acc - @dt, remaining_steps - 1, state)
   end
 
   defp simulate_steps(acc, _, _state), do: acc
 
-  defp broadcast_move_command do
-    :particle_data
+  defp broadcast_move_command(game_id, ets_table) do
+    ets_table
     |> :ets.tab2list()
-    |> Task.async_stream(&GenServer.call(Particle.via_tuple(elem(&1, 0)), {:move, @dt}, 5000))
+    |> Task.async_stream(fn particle_data ->
+      particle_id = elem(particle_data, 0)
+      GenServer.call(Particle.via_tuple(game_id, particle_id), {:move, @dt}, 5000)
+    end)
     |> Stream.run()
   end
 
-  # --- Lógica de Colisão Síncrona ---
-
   defp detect_and_resolve_collisions(state) do
-    all_particles = :ets.tab2list(:particle_data)
+    all_particles = :ets.tab2list(state.ets_table)
 
     if not Enum.empty?(all_particles) do
       {ids, initial_states} = batch_particles(all_particles)
+
       final_states =
         iterative_resolution_loop(
           state.inactive_table,
           initial_states,
           @resolution_iterations
         )
-      dispatch_final_updates(ids, initial_states, final_states)
+
+      dispatch_final_updates(state.game_id, ids, initial_states, final_states)
     end
   end
 
@@ -150,6 +192,7 @@ defmodule SnookerGameEx.CollisionEngine do
       if Nx.axis_size(colliding_pairs_tensor, 0) > 0 do
         collision_results =
           Physics.calculate_collision_responses(current_states, colliding_pairs_tensor)
+
         updated_states = Physics.apply_collision_updates(current_states, collision_results)
         iterative_resolution_loop(table, updated_states, iterations_left - 1)
       else
@@ -158,8 +201,7 @@ defmodule SnookerGameEx.CollisionEngine do
     end
   end
 
-  @doc false
-  defp dispatch_final_updates(ids, initial_states, final_states) do
+  defp dispatch_final_updates(game_id, ids, initial_states, final_states) do
     pos_diff = Nx.abs(Nx.subtract(initial_states.pos, final_states.pos))
     max_diff_per_particle = Nx.reduce_max(pos_diff, axes: [1])
     changed_mask = Nx.greater(max_diff_per_particle, 1.0e-6)
@@ -180,16 +222,20 @@ defmodule SnookerGameEx.CollisionEngine do
         particle_id = elem(ids_tuple, index)
         new_pos = Enum.at(final_pos_list, index)
         new_vel = Enum.at(final_vel_list, index)
-        GenServer.cast(Particle.via_tuple(particle_id), {:update_after_collision, new_vel, new_pos})
+
+        GenServer.cast(
+          Particle.via_tuple(game_id, particle_id),
+          {:update_after_collision, new_vel, new_pos}
+        )
       end
     end
   end
 
-  # --- Funções Auxiliares ---
   defp find_candidate_pairs(table, states) do
     num_particles = Nx.axis_size(states.pos, 0)
     positions_list = Nx.to_list(states.pos)
     radii_list = Nx.to_list(states.radius)
+
     0..(num_particles - 1)
     |> Task.async_stream(
       fn index ->
@@ -206,7 +252,9 @@ defmodule SnookerGameEx.CollisionEngine do
   defp build_spatial_structure(table, states) do
     Quadtree.clear(table)
     positions_list = Nx.to_list(states.pos)
-    Enum.with_index(positions_list) |> Enum.each(fn {point, index} -> Quadtree.insert(table, point, index) end)
+
+    Enum.with_index(positions_list)
+    |> Enum.each(fn {point, index} -> Quadtree.insert(table, point, index) end)
   end
 
   defp batch_particles(all_particles) do
@@ -215,14 +263,15 @@ defmodule SnookerGameEx.CollisionEngine do
     vel_idx = Particle.get_attr_index(:vel)
     radius_idx = Particle.get_attr_index(:radius)
     mass_idx = Particle.get_attr_index(:mass)
+
     states = %{
       pos: Enum.map(all_particles, &elem(&1, pos_idx)) |> Nx.tensor(),
       vel: Enum.map(all_particles, &elem(&1, vel_idx)) |> Nx.tensor(),
-      # --- CORREÇÃO FINAL DO ERRO DE DIGITAÇÃO ---
       radius:
         Enum.map(all_particles, &elem(&1, radius_idx)) |> Nx.tensor() |> Nx.reshape({:auto, 1}),
       mass: Enum.map(all_particles, &elem(&1, mass_idx)) |> Nx.tensor() |> Nx.reshape({:auto, 1})
     }
+
     {ids, states}
   end
 end

--- a/lib/snooker_game_ex/collision_engine.ex
+++ b/lib/snooker_game_ex/collision_engine.ex
@@ -11,7 +11,6 @@ defmodule SnookerGameEx.CollisionEngine do
   alias SnookerGameEx.Particle
   alias SnookerGameEx.Physics
 
-  # ... (constantes permanecem as mesmas) ...
   @frame_interval_ms 16
   @dt @frame_interval_ms / 1000.0
   @resolution_iterations 10

--- a/lib/snooker_game_ex/game_instance_supervisor.ex
+++ b/lib/snooker_game_ex/game_instance_supervisor.ex
@@ -1,0 +1,45 @@
+defmodule SnookerGameEx.GameInstanceSupervisor do
+  @moduledoc """
+  Supervisor para uma única instância de um jogo de sinuca.
+  Gerencia o CollisionEngine e o ParticleSupervisor para um jogo específico.
+  Esta versão usa identificadores de tabela ETS (tids) para evitar vazamentos de memória de átomos.
+  """
+  use Supervisor
+
+  def start_link(game_id) do
+    Supervisor.start_link(__MODULE__, game_id, name: via_tuple(game_id))
+  end
+
+  def via_tuple(game_id), do: {:via, Registry, {SnookerGameEx.GameRegistry, game_id}}
+
+  @impl true
+  def init(game_id) do
+    # SOLUÇÃO 1: Criar a tabela sem um nome de átomo dinâmico.
+    # `:ets.new` retorna um identificador de tabela (tid) que é seguro para usar e é coletado pelo garbage collector.
+    # O primeiro argumento é um nome apenas para fins de depuração em observadores, não para acesso.
+    ets_table_tid =
+      :ets.new(:game_ets_table, [:set, :public, read_concurrency: true, write_concurrency: true])
+
+    children = [
+      # Passa o tid seguro para os processos filhos.
+      {SnookerGameEx.CollisionEngine, game_id: game_id, ets_table: ets_table_tid},
+      {SnookerGameEx.ParticleSupervisor, game_id: game_id, ets_table: ets_table_tid}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  @doc """
+  Reinicia uma instância de jogo terminando seu processo supervisor.
+  O `GameSupervisor` (DynamicSupervisor) o recriará quando for solicitado novamente.
+  """
+  def restart(game_id) do
+    case Registry.lookup(SnookerGameEx.GameRegistry, game_id) do
+      [{pid, _}] ->
+        DynamicSupervisor.terminate_child(SnookerGameEx.GameSupervisor, pid)
+
+      [] ->
+        :ok
+    end
+  end
+end

--- a/lib/snooker_game_ex/game_supervisor.ex
+++ b/lib/snooker_game_ex/game_supervisor.ex
@@ -1,0 +1,32 @@
+defmodule SnookerGameEx.GameSupervisor do
+  @moduledoc """
+  Um supervisor dinâmico que gerencia o ciclo de vida de todas as instâncias de jogos.
+  Cada jogo é executado em sua própria árvore de supervisão para garantir o isolamento.
+  """
+  use DynamicSupervisor
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @doc """
+  Inicia uma nova instância de jogo para o game_id fornecido, a menos que já exista.
+  """
+  def start_game(game_id) do
+    # Usa um registro para verificar se o jogo já está em execução para evitar race conditions
+    case Registry.lookup(SnookerGameEx.GameRegistry, game_id) do
+      [] ->
+        spec = {SnookerGameEx.GameInstanceSupervisor, game_id}
+        DynamicSupervisor.start_child(__MODULE__, spec)
+
+      _ ->
+        # O jogo já está em execução, não faz nada
+        :ok
+    end
+  end
+end

--- a/lib/snooker_game_ex/particle.ex
+++ b/lib/snooker_game_ex/particle.ex
@@ -48,10 +48,10 @@ defmodule SnookerGameEx.Particle do
         0.0
       }
 
-    # CORREÇÃO: Usando a variável `ets_table` correta.
+    # Usando a variável `ets_table` correta.
     :ets.insert(ets_table, particle_tuple)
 
-    # CORREÇÃO: Usando a variável `particle_tuple` correta e definindo o estado inicial do GenServer.
+    #d Usando a variável `particle_tuple` correta e definindo o estado inicial do GenServer.
     state = {game_id, ets_table, particle_tuple}
     {:ok, state}
   end
@@ -61,11 +61,11 @@ defmodule SnookerGameEx.Particle do
     if Physics.velocity_magnitude(elem(current_data, get_attr_index(:vel))) < 0.01 do
       new_data = put_elem(current_data, get_attr_index(:vel), [0.0, 0.0])
 
-      # CORREÇÃO: Usando `ets_table` e passando `game_id` para o broadcast.
+      # Usando `ets_table` e passando `game_id` para o broadcast.
       :ets.insert(ets_table, new_data)
       broadcast_update(game_id, new_data)
 
-      # CORREÇÃO: Retornando a estrutura de estado completa e correta.
+      # Retornando a estrutura de estado completa e correta.
       new_state = {game_id, ets_table, new_data}
       {:reply, :ok, new_state}
     else
@@ -111,18 +111,15 @@ defmodule SnookerGameEx.Particle do
           |> put_elem(get_attr_index(:spin_angle), new_spin_angle)
           |> put_elem(get_attr_index(:roll_distance), new_roll_distance)
 
-        # CORREÇÃO: Usando a variável `new_data` correta.
         :ets.insert(ets_table, new_data)
         broadcast_update(game_id, new_data)
 
-        # CORREÇÃO: Retornando a estrutura de estado completa e correta.
         new_state = {game_id, ets_table, new_data}
         {:reply, :ok, new_state}
       end
     end
   end
 
-  # CORREÇÃO: Todos os handle_cast foram atualizados para usar a estrutura de estado correta.
   @impl true
   def handle_cast(
         {:update_after_collision, new_velocity, new_position},

--- a/lib/snooker_game_ex/particle.ex
+++ b/lib/snooker_game_ex/particle.ex
@@ -1,31 +1,39 @@
 defmodule SnookerGameEx.Particle do
   @moduledoc """
-  Represents a single particle (a ball) in the simulation.
+  Representa uma única partícula (uma bola) na simulação de um jogo específico.
   """
   use GenServer
 
   alias SnookerGameEx.Physics
   alias SnookerGameEx.CollisionEngine
 
-  @game_events_topic "game_events"
   @simulation_topic "particle_updates"
+  @game_events_topic "game_events"
 
-  @typedoc "The particle state now tracks spin and roll independently."
-  @type particle_state ::
+  @typedoc "O estado do GenServer armazena os dados do jogo e da partícula."
+  @type state :: {game_id :: String.t(), ets_table :: atom(), particle_data :: particle_tuple()}
+
+  @typedoc "A tupla que representa os dados brutos de uma partícula."
+  @type particle_tuple ::
           {id :: any(), pos :: list(float()), vel :: list(float()), radius :: float(),
            mass :: float(), color :: map(), spin_angle :: float(), roll_distance :: float()}
 
-  @doc "Starts a particle GenServer."
+  @doc "Inicia um GenServer de partícula para um jogo específico."
   @spec start_link(list) :: GenServer.on_start()
   def start_link(opts) do
+    game_id = Keyword.fetch!(opts, :game_id)
     id = Keyword.fetch!(opts, :id)
-    GenServer.start_link(__MODULE__, opts, name: via_tuple(id))
+    GenServer.start_link(__MODULE__, opts, name: via_tuple(game_id, id))
   end
 
-  def via_tuple(id), do: {:via, Registry, {SnookerGameEx.ParticleRegistry, id}}
+  def via_tuple(game_id, id),
+    do: {:via, Registry, {SnookerGameEx.ParticleRegistry, {game_id, id}}}
 
   @impl true
   def init(opts) do
+    ets_table = Keyword.fetch!(opts, :ets_table)
+    game_id = Keyword.fetch!(opts, :game_id)
+
     particle_tuple =
       {
         Keyword.fetch!(opts, :id),
@@ -40,32 +48,37 @@ defmodule SnookerGameEx.Particle do
         0.0
       }
 
-    :ets.insert(:particle_data, particle_tuple)
-    {:ok, particle_tuple}
+    # CORREÇÃO: Usando a variável `ets_table` correta.
+    :ets.insert(ets_table, particle_tuple)
+
+    # CORREÇÃO: Usando a variável `particle_tuple` correta e definindo o estado inicial do GenServer.
+    state = {game_id, ets_table, particle_tuple}
+    {:ok, state}
   end
 
   @impl true
-  def handle_call({:move, dt}, _from, current_state) do
-    if Physics.velocity_magnitude(elem(current_state, 2)) < 0.01 do
-      new_state = put_elem(current_state, get_attr_index(:vel), [0.0, 0.0])
-      :ets.insert(:particle_data, new_state)
-      broadcast_update(new_state)
+  def handle_call({:move, dt}, _from, {game_id, ets_table, current_data} = state) do
+    if Physics.velocity_magnitude(elem(current_data, get_attr_index(:vel))) < 0.01 do
+      new_data = put_elem(current_data, get_attr_index(:vel), [0.0, 0.0])
+
+      # CORREÇÃO: Usando `ets_table` e passando `game_id` para o broadcast.
+      :ets.insert(ets_table, new_data)
+      broadcast_update(game_id, new_data)
+
+      # CORREÇÃO: Retornando a estrutura de estado completa e correta.
+      new_state = {game_id, ets_table, new_data}
       {:reply, :ok, new_state}
     else
       bounds = CollisionEngine.world_bounds()
-      {id, pos, vel, radius, _mass, color, current_spin, current_roll} = current_state
+      {id, pos, vel, radius, _mass, color, current_spin, current_roll} = current_data
 
       friction = CollisionEngine.friction_coefficient()
       [vx, vy] = vel
       damping_factor = :math.pow(1.0 - friction, dt)
       damped_vel = [vx * damping_factor, vy * damping_factor]
 
-      # --- Calcula ambas as rotações ---
       distance_moved = Physics.velocity_magnitude(damped_vel) * dt
-      # Rolagem é a distância acumulada
       new_roll_distance = current_roll + distance_moved
-      # Giro é um ângulo que também aumenta com a distância
-      # O fator 0.5 torna o giro mais sutil
       new_spin_angle = current_spin + distance_moved / radius * 0.01
 
       [px, py] = pos
@@ -84,73 +97,88 @@ defmodule SnookerGameEx.Particle do
       if Physics.pocketed?(final_pos, pockets, pocket_radius) do
         Phoenix.PubSub.broadcast(
           SnookerGameEx.PubSub,
-          @game_events_topic,
+          "#{@game_events_topic}:#{game_id}",
           {:ball_pocketed, id, color}
         )
 
-        :ets.delete(:particle_data, id)
-        {:stop, :normal, :ok, current_state}
+        :ets.delete(ets_table, id)
+        {:stop, :normal, :ok, state}
       else
-        new_state =
-          current_state
+        new_data =
+          current_data
           |> put_elem(get_attr_index(:pos), final_pos)
           |> put_elem(get_attr_index(:vel), final_vel)
           |> put_elem(get_attr_index(:spin_angle), new_spin_angle)
           |> put_elem(get_attr_index(:roll_distance), new_roll_distance)
 
-        :ets.insert(:particle_data, new_state)
-        broadcast_update(new_state)
+        # CORREÇÃO: Usando a variável `new_data` correta.
+        :ets.insert(ets_table, new_data)
+        broadcast_update(game_id, new_data)
+
+        # CORREÇÃO: Retornando a estrutura de estado completa e correta.
+        new_state = {game_id, ets_table, new_data}
         {:reply, :ok, new_state}
       end
     end
   end
 
+  # CORREÇÃO: Todos os handle_cast foram atualizados para usar a estrutura de estado correta.
   @impl true
-  def handle_cast({:update_after_collision, new_velocity, new_position}, current_state) do
-    new_state =
-      current_state
+  def handle_cast(
+        {:update_after_collision, new_velocity, new_position},
+        {game_id, ets_table, current_data}
+      ) do
+    new_data =
+      current_data
       |> put_elem(get_attr_index(:vel), new_velocity)
       |> put_elem(get_attr_index(:pos), new_position)
-      # Reseta a rolagem na colisão
       |> put_elem(get_attr_index(:roll_distance), 0.0)
 
-    :ets.insert(:particle_data, new_state)
-    broadcast_update(new_state)
+    :ets.insert(ets_table, new_data)
+    broadcast_update(game_id, new_data)
+
+    new_state = {game_id, ets_table, new_data}
     {:noreply, new_state}
   end
 
   @impl true
-  def handle_cast(:hold, current_state) do
-    new_velocity = [0, 0]
-
-    new_state =
-      current_state
-      |> put_elem(get_attr_index(:vel), new_velocity)
+  def handle_cast(:hold, {game_id, ets_table, current_data}) do
+    new_data =
+      current_data
+      |> put_elem(get_attr_index(:vel), [0.0, 0.0])
       |> put_elem(get_attr_index(:spin_angle), 0.0)
       |> put_elem(get_attr_index(:roll_distance), 0.0)
 
-    :ets.insert(:particle_data, new_state)
+    :ets.insert(ets_table, new_data)
+    # Não há necessidade de broadcast para 'hold', mas a atualização do ETS é mantida.
+
+    new_state = {game_id, ets_table, new_data}
     {:noreply, new_state}
   end
 
   @impl true
-  def handle_cast({:apply_force, [fx, fy]}, current_state) do
-    {_id, _pos, [vx, vy], _radius, mass, _color, _spin, _roll} = current_state
+  def handle_cast({:apply_force, [fx, fy]}, {game_id, ets_table, current_data}) do
+    {_id, _pos, [vx, vy], _radius, mass, _color, _spin, _roll} = current_data
     new_velocity = [vx + fx / mass, vy + fy / mass]
 
-    new_state =
-      current_state
+    new_data =
+      current_data
       |> put_elem(get_attr_index(:vel), new_velocity)
-      # Reseta ambos na tacada
       |> put_elem(get_attr_index(:spin_angle), 0.0)
       |> put_elem(get_attr_index(:roll_distance), 0.0)
 
-    :ets.insert(:particle_data, new_state)
+    :ets.insert(ets_table, new_data)
+
+    # O broadcast ocorrerá naturalmente no próximo tick de :move, então não é estritamente necessário aqui.
+    # Mas podemos adicioná-lo para uma resposta mais imediata.
+    broadcast_update(game_id, new_data)
+
+    new_state = {game_id, ets_table, new_data}
     {:noreply, new_state}
   end
 
-  @spec broadcast_update(particle_state()) :: :ok
-  def broadcast_update(particle_tuple) do
+  @spec broadcast_update(String.t(), particle_tuple()) :: :ok
+  def broadcast_update(game_id, particle_tuple) do
     payload = %{
       id: elem(particle_tuple, get_attr_index(:id)),
       pos: elem(particle_tuple, get_attr_index(:pos)),
@@ -161,7 +189,11 @@ defmodule SnookerGameEx.Particle do
       roll_distance: elem(particle_tuple, get_attr_index(:roll_distance))
     }
 
-    Phoenix.PubSub.broadcast(SnookerGameEx.PubSub, @simulation_topic, {:particle_moved, payload})
+    Phoenix.PubSub.broadcast(
+      SnookerGameEx.PubSub,
+      "#{@simulation_topic}:#{game_id}",
+      {:particle_moved, payload}
+    )
   end
 
   @spec get_attr_index(atom()) :: non_neg_integer()

--- a/lib/snooker_game_ex/particle_supervisor.ex
+++ b/lib/snooker_game_ex/particle_supervisor.ex
@@ -1,66 +1,69 @@
 defmodule SnookerGameEx.ParticleSupervisor do
   @moduledoc """
   A dynamic supervisor responsible for starting and managing the lifecycle
-  of `Particle` processes.
+  of `Particle` processes for a specific game instance.
   """
   use Supervisor
 
   @spacing_buffer 2.5
 
-  # Define the standard 8-ball pool set.
-  # Number 0 is the cue ball.
-  # Numbers 1-7 are solids.
-  # Number 8 is the 8-ball.
-  # Numbers 9-15 are stripes.
+  # Define o conjunto padrão de bolas de sinuca (8-ball).
   @pool_ball_set [
-    # Yellow
+    # Amarela
     %{number: 1, type: :solid, base_color: "#fdd835"},
-    # Blue
+    # Azul
     %{number: 2, type: :solid, base_color: "#1e88e5"},
-    # Red
+    # Vermelha
     %{number: 3, type: :solid, base_color: "#e53935"},
-    # Purple
+    # Roxa
     %{number: 4, type: :solid, base_color: "#8e24aa"},
-    # Orange
+    # Laranja
     %{number: 5, type: :solid, base_color: "#fb8c00"},
-    # Green
+    # Verde
     %{number: 6, type: :solid, base_color: "#43a047"},
-    # Maroon/Brown
+    # Marrom
     %{number: 7, type: :solid, base_color: "#5d4037"},
-    # Black
+    # Preta
     %{number: 8, type: :solid, base_color: "#212121"},
-    # Yellow Stripe
+    # Amarela Listrada
     %{number: 9, type: :stripe, base_color: "#fdd835"},
-    # Blue Stripe
+    # Azul Listrada
     %{number: 10, type: :stripe, base_color: "#1e88e5"},
-    # Red Stripe
+    # Vermelha Listrada
     %{number: 11, type: :stripe, base_color: "#e53935"},
-    # Purple Stripe
+    # Roxa Listrada
     %{number: 12, type: :stripe, base_color: "#8e24aa"},
-    # Orange Stripe
+    # Laranja Listrada
     %{number: 13, type: :stripe, base_color: "#fb8c00"},
-    # Green Stripe
+    # Verde Listrada
     %{number: 14, type: :stripe, base_color: "#43a047"},
-    # Maroon/Brown Stripe
+    # Marrom Listrada
     %{number: 15, type: :stripe, base_color: "#5d4037"}
   ]
 
-  @doc "Starts the particle supervisor."
-  @spec start_link(any()) :: Supervisor.on_start()
-  def start_link(init_arg) do
-    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  @doc "Inicia o supervisor de partículas para um jogo específico."
+  def start_link(opts) do
+    game_id = Keyword.fetch!(opts, :game_id)
+    Supervisor.start_link(__MODULE__, opts, name: via_tuple(game_id))
   end
 
+  def via_tuple(game_id),
+    do: {:via, Registry, {SnookerGameEx.GameRegistry, {__MODULE__, game_id}}}
+
   @impl true
-  def init(_init_arg) do
-    # Creates the ETS table that will store all particle state data for quick access.
-    maybe_create_ets_table()
+  def init(opts) do
+    game_id = Keyword.fetch!(opts, :game_id)
+    ets_table = Keyword.fetch!(opts, :ets_table)
+
+    # CORREÇÃO: Removida a chamada para maybe_create_ets_table().
+    # A tabela ETS agora é criada pelo GameInstanceSupervisor com um nome
+    # específico para o jogo e passada para este módulo via `opts`.
 
     bounds = SnookerGameEx.CollisionEngine.world_bounds()
     radius = SnookerGameEx.CollisionEngine.particle_radius()
     diameter = radius * 2
 
-    # --- Initial Ball Positioning ---
+    # --- Posicionamento Inicial das Bolas ---
     center_y = bounds.y + bounds.h / 2
     white_ball_pos = [bounds.x + 200, center_y]
     apex_pos = %{x: bounds.x + 700, y: center_y}
@@ -68,13 +71,12 @@ defmodule SnookerGameEx.ParticleSupervisor do
     row_separation = radius * :math.sqrt(3) + @spacing_buffer
     vertical_separation = diameter + @spacing_buffer
 
-    # Shuffle the pool ball set for a random rack each time.
+    # Embaralha o conjunto de bolas para uma organização aleatória a cada vez.
     rack_balls = Enum.shuffle(@pool_ball_set)
 
-    # Generates the positions for the 15 balls in the triangular rack.
+    # Gera as posições para as 15 bolas no triângulo.
     triangle_positions =
       Stream.unfold(0, fn
-        # Stop after 5 rows (1+2+3+4+5 = 15 balls)
         5 ->
           nil
 
@@ -94,55 +96,60 @@ defmodule SnookerGameEx.ParticleSupervisor do
       |> Enum.flat_map(& &1)
       |> Enum.take(15)
 
-    # Creates the child specs for the colored balls.
+    # CORREÇÃO: A lógica para criar os `children` foi simplificada e corrigida
+    # para passar todos os argumentos necessários (`game_id`, `ets_table`, etc.)
+    # para a função `particle_spec`.
+
+    # Cria as especificações dos filhos para as bolas coloridas.
     colored_balls =
       Enum.zip(rack_balls, triangle_positions)
-      # Start IDs from 1, as 0 is the white ball.
+      # IDs começam em 1, já que 0 é a bola branca.
       |> Enum.with_index(1)
       |> Enum.map(fn {{ball_data, pos}, id} ->
-        # Pass the entire map of ball data to the particle spec.
-        particle_spec(id, ball_data, pos)
+        # Passa todos os dados necessários para a especificação da partícula.
+        particle_spec(game_id, ets_table, id, ball_data, pos)
       end)
 
-    # Combine all child specs for the supervisor.
+    # Combina todas as especificações dos filhos para o supervisor.
     children = [
-      # White Ball / Cue Ball (ID 0)
-      particle_spec(0, %{number: 0, type: :cue, base_color: "white"}, white_ball_pos)
-      # The rest of the balls
+      # Bola Branca (ID 0)
+      particle_spec(
+        game_id,
+        ets_table,
+        0,
+        %{number: 0, type: :cue, base_color: "white"},
+        white_ball_pos
+      )
+      # O resto das bolas
       | colored_balls
     ]
 
-    Supervisor.init(children, strategy: :one_for_one, restart: :transient)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 
-  defp maybe_create_ets_table do
-    if :ets.whereis(:particle_data) == :undefined do
-      :ets.new(:particle_data, [
-        :set,
-        :public,
-        :named_table,
-        read_concurrency: true,
-        write_concurrency: true
-      ])
-    end
-  end
+  # CORREÇÃO: A função `maybe_create_ets_table` foi removida completamente.
+  # Ela não é mais necessária, pois a tabela ETS é gerenciada pelo
+  # GameInstanceSupervisor.
 
-  # --- Private Helper ---
+  # --- Função Auxiliar Privada ---
 
-  # The 'color' parameter is now a map containing all visual data for the ball.
-  defp particle_spec(id, ball_data, pos) do
+  defp particle_spec(game_id, ets_table, id, ball_data, pos) do
     %{
-      id: id,
+      # O ID do filho para o supervisor deve ser único. Uma tupla com game_id e id da bola funciona bem.
+      id: {game_id, id},
       start:
         {SnookerGameEx.Particle, :start_link,
          [
+           # CORREÇÃO: Adicionado `ets_table: ets_table` à lista de opções.
+           # O processo Particle precisa saber qual tabela ETS usar.
            [
+             game_id: game_id,
+             ets_table: ets_table,
              id: id,
              pos: pos,
              vel: [0, 0],
              radius: SnookerGameEx.CollisionEngine.particle_radius(),
              mass: SnookerGameEx.CollisionEngine.particle_mass(),
-             # Pass the whole map
              color: ball_data
            ]
          ]},
@@ -152,7 +159,13 @@ defmodule SnookerGameEx.ParticleSupervisor do
   end
 
   @doc """
-  Restart the supervisor, putting all particles in their initial states
+  Reinicia a instância de jogo associada, colocando todas as partículas
+  em seus estados iniciais.
   """
-  def restart, do: Supervisor.stop(__MODULE__)
+  def restart(game_id) do
+    # A lógica de reinicialização foi movida para o GameInstanceSupervisor (ou similar).
+    # Esta chamada está correta se CollisionEngine.restart/1 lida com o reinício
+    # da árvore de supervisão do jogo.
+    SnookerGameEx.CollisionEngine.restart(game_id)
+  end
 end

--- a/lib/snooker_game_ex/particle_supervisor.ex
+++ b/lib/snooker_game_ex/particle_supervisor.ex
@@ -55,7 +55,7 @@ defmodule SnookerGameEx.ParticleSupervisor do
     game_id = Keyword.fetch!(opts, :game_id)
     ets_table = Keyword.fetch!(opts, :ets_table)
 
-    # CORREÇÃO: Removida a chamada para maybe_create_ets_table().
+    # Removida a chamada para maybe_create_ets_table().
     # A tabela ETS agora é criada pelo GameInstanceSupervisor com um nome
     # específico para o jogo e passada para este módulo via `opts`.
 
@@ -96,7 +96,7 @@ defmodule SnookerGameEx.ParticleSupervisor do
       |> Enum.flat_map(& &1)
       |> Enum.take(15)
 
-    # CORREÇÃO: A lógica para criar os `children` foi simplificada e corrigida
+    # A lógica para criar os `children` foi simplificada e corrigida
     # para passar todos os argumentos necessários (`game_id`, `ets_table`, etc.)
     # para a função `particle_spec`.
 
@@ -127,7 +127,7 @@ defmodule SnookerGameEx.ParticleSupervisor do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
-  # CORREÇÃO: A função `maybe_create_ets_table` foi removida completamente.
+  # A função `maybe_create_ets_table` foi removida completamente.
   # Ela não é mais necessária, pois a tabela ETS é gerenciada pelo
   # GameInstanceSupervisor.
 
@@ -140,7 +140,7 @@ defmodule SnookerGameEx.ParticleSupervisor do
       start:
         {SnookerGameEx.Particle, :start_link,
          [
-           # CORREÇÃO: Adicionado `ets_table: ets_table` à lista de opções.
+           # Adicionado `ets_table: ets_table` à lista de opções.
            # O processo Particle precisa saber qual tabela ETS usar.
            [
              game_id: game_id,

--- a/lib/snooker_game_ex/spatial_hashing.ex
+++ b/lib/snooker_game_ex/spatial_hashing.ex
@@ -127,7 +127,7 @@ defmodule SnookerGameEx.SpatialHash do
 
   @doc "Calcula o intervalo de coordenadas de células que um envelope sobrepõe."
   @spec get_cell_range(envelope, map) :: {%Range{}, %Range{}}
-  defp get_cell_range(envelope, config) do
+  def get_cell_range(envelope, config) do
     %{bounds: bounds, cell_size: cell_size} = config
 
     min_cx = get_cell_coord(envelope.min_x, bounds.x, cell_size)
@@ -140,7 +140,7 @@ defmodule SnookerGameEx.SpatialHash do
 
   @doc "Converte uma coordenada do mundo para uma coordenada da grade."
   @spec get_cell_coord(number, number, number) :: integer
-  defp get_cell_coord(pos, origin, cell_size) do
+  def get_cell_coord(pos, origin, cell_size) do
     floor((pos - origin) / cell_size)
   end
 end

--- a/lib/snooker_game_ex/spatial_hashing_ets.ex
+++ b/lib/snooker_game_ex/spatial_hashing_ets.ex
@@ -65,7 +65,7 @@ defmodule SnookerGameEx.SpatialHashETS do
   Converts world coordinates to grid cell coordinates.
   """
   @spec to_cell_coords({x :: float(), y :: float()}, cell_size :: pos_integer()) :: cell_key
-  defp to_cell_coords({x, y}, cell_size) do
+  def to_cell_coords({x, y}, cell_size) do
     {div(floor(x), cell_size), div(floor(y), cell_size)}
   end
 

--- a/lib/snooker_game_ex_web/router.ex
+++ b/lib/snooker_game_ex_web/router.ex
@@ -18,7 +18,8 @@ defmodule SnookerGameExWeb.Router do
     pipe_through :browser
 
     # get "/", PageController, :home
-    live "/", SnookerGameLive
+    # live "/", SnookerGameLive
+    live "/room/:game_id", SnookerGameLive, :show
   end
 
   # Other scopes may use custom stacks.

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule SnookerGameEx.MixProject do
   def application do
     [
       mod: {SnookerGameEx.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :observer, :wx]
     ]
   end
 


### PR DESCRIPTION
This change refactors the application from a single, global game instance to an architecture that supports multiple, isolated game instances, each running in its own supervision tree.

Key changes:

- Dynamic Supervision: Introduces a GameSupervisor (DynamicSupervisor) to dynamically start and stop game instance supervisors (GameInstanceSupervisor).

- Process Isolation: Each game instance, with its own CollisionEngine and ParticleSupervisor, is isolated. Processes are registered in a Registry using a game_id to prevent name clashes.

- State Isolation (ETS): Abandons the use of a global, named ETS table. Instead, each game instance creates its own ETS table (using a tid instead of an atom name), which is passed to child processes. This solves the atom exhaustion problem and ensures game data is completely separate.

- Routing and Frontend: The Phoenix LiveView route is changed to "/room/:game_id". The LiveView now subscribes to game-specific PubSub topics and passes the game_id to backend event handlers.

- Quadtree Refactoring: The Quadtree module was modified to no longer depend on an ETS table name. Instead, it operates on a table reference (tid) provided during initialization, making it more modular and safer for use in concurrent environments.